### PR TITLE
Rename Street Coverage to Cycling Denver, flag the modal link

### DIFF
--- a/src/components/work.tsx
+++ b/src/components/work.tsx
@@ -2,6 +2,8 @@ import {
   Badge,
   Box,
   Heading,
+  Icon,
+  IconProps,
   Link,
   Modal,
   ModalBody,
@@ -40,6 +42,19 @@ const StyledGatsbyImage = styled(GatsbyImage)`
   height: 275px;
   background-color: #e2e8f0;
 `;
+
+// Chakra's ExternalLinkIcon lives in @chakra-ui/icons, which isn't a dependency
+// here — inlined rather than pulling in a package for one glyph.
+const ExternalLinkIcon = (props: IconProps) => (
+  <Icon viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" {...props}>
+    <path
+      d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+    />
+    <path d="M15 3h6v6M10 14 21 3" strokeLinecap="round" strokeLinejoin="round" />
+  </Icon>
+);
 
 const FallbackCover = styled.div`
   height: 275px;
@@ -157,8 +172,17 @@ export const Work: React.FC<WorkProps> = ({ data, title = "Work" }) => {
           <ModalHeader pb="2">
             <Box fontSize="2xl" fontWeight="bold">
               {selected?.url ? (
-                <Link href={selected.url} isExternal color="teal.700">
+                <Link
+                  href={selected.url}
+                  isExternal
+                  color="teal.700"
+                  display="inline-flex"
+                  alignItems="center"
+                  gap="2"
+                  aria-label={`${selected.clientName} (opens in a new tab)`}
+                >
                   {selected.clientName}
+                  <ExternalLinkIcon boxSize="0.7em" aria-hidden focusable="false" />
                 </Link>
               ) : (
                 selected?.clientName

--- a/src/content/fun/streetcoverage/streetcoverage.mdx
+++ b/src/content/fun/streetcoverage/streetcoverage.mdx
@@ -1,5 +1,5 @@
 ---
-clientName: "Street Coverage"
+clientName: "Cycling Denver"
 url: "https://cycling.nathanbeekman.com"
 project: "Ride Every Street"
 startDate: 2026-07-27
@@ -13,7 +13,9 @@ technology: ["react 19", "typescript", "deck.gl", "maplibre", "openstreetmap", "
 overview: |
   A completionist map for cyclists: every rideable street in the Denver metro, drawn from OpenStreetMap, with my own Strava history painted over the top. The percentage goes up as I ride. It has already changed how I plan routes, which was the whole point.
 
-  The metro core is 68,574 streets across nineteen municipalities and park boundaries — 12,346 km of pavement. All of it renders in the browser as a single deck.gl PathLayer fed binary typed arrays, with no geometry simplification and no web worker; measured at 51k paths, the network layer held 60fps while panning. Geometry is kept in Float64 for the coverage math but uploaded as Float32 offsets from a per-region origin, because raw Float32 longitude carries about 1.4 m of error at Denver's longitude — unusable next to a 25 m coverage radius.
+  The metro core is 68,574 streets across nineteen municipalities and park boundaries — 12,346 km of pavement, and 69,791 rendered paths once each street is split by which parts I've ridden. It all goes to the GPU as a single deck.gl PathLayer fed binary typed arrays, with no geometry simplification and no web worker. Geometry is kept in Float64 for the coverage math but uploaded as Float32 offsets from a per-region origin, because raw Float32 carries about 1.4 m of error at Denver's longitude — unusable next to a 25 m coverage radius.
+
+  Zooming out used to collapse the framerate to 6fps: with no culling, the entire network kept rasterizing even when the metro occupied a few hundred pixels. The fix took three attempts, and what it actually depended on was unglamorous — memoizing the binary data object and its accessors per region. deck.gl diffs layer props by reference, so building a fresh wrapper each render reads as new data and re-uploads all 613,505 vertices; culling rebuilds layers as the camera moves, which meant both earlier attempts cost more than the problem did. With the references held stable, viewport culling in a CompositeLayer works, and continental zoom went from 6fps to 29. Nine tests pin the reference identity specifically, because a value-equality test would pass while the bug quietly came back.
 
   Most of the real work turned out to be data, not rendering. Regions are incorporated places rather than counties, since a county boundary includes mountain roads nobody will ever ride and would put 100% permanently out of reach. That choice creates its own problem: the strip between Littleton and Morrison belongs to no municipality at all, so it needs an explicitly drawn polygon region to pick up S Kipling Pkwy and the C-470 Trail. Overpass also hands back any street with a single node inside a boundary, so 395 ways along shared borders were being claimed by two cities at once and inflating the denominator by 127 km before I caught it.
 


### PR DESCRIPTION
Follows the project's own rename — the live site's `<title>`, README and `package.json` all read Cycling Denver now, so the portfolio matched the old name on click-through.

**Modal link affordance.** The title has been a link since #21 but read as plain text. It now gets an external-link glyph and an `aria-label` announcing that it opens in a new tab. `@chakra-ui/icons` isn't a dependency here, so the SVG is inlined via Chakra's `Icon` rather than adding a package for one glyph.

**Render claim corrected.** Viewport culling landed after #21 was written and moved the numbers in both directions:

| | Before | After |
|---|---:|---:|
| Continental zoom | 6 fps | **29 fps** |
| City zoom | 48–60 fps | **29–30 fps** |

The old "60fps while panning" line no longer described the deployed site, so it's replaced with the culling story — including why the first two attempts were slower than the bug (deck.gl diffs layer props by reference, so rebuilding the `data` wrapper re-uploaded all 613,505 vertices every frame culling touched a layer). The trade is stated rather than just the win.

Verified with `gatsby build` under Node 18.16.0 — clean. `tsc --noEmit` reports only pre-existing errors in `layout.tsx`, `404.tsx` and `node_modules`; nothing from `work.tsx`. Confirmed the icon path and aria-label compile into the page bundle.